### PR TITLE
Remove oracle-java9-set-default addon for travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 language: node_js
 sudo: required
 jdk: oraclejdk8
-addons:
-  apt:
-    packages:
-      - oracle-java9-set-default
 branches:
   only:
     - master


### PR DESCRIPTION
Travis-ci failed to build due to missing addon oracle java9 default.
https://travis-ci.com/cerner/ascvd-risk-calculator/jobs/252671269

Removing this addon to correct missing oracle java9
See this post: https://github.com/travis-ci/travis-ci/issues/9891#issuecomment-405873788